### PR TITLE
Updated never expiring discord invite link in footer section.

### DIFF
--- a/Insight_Quirk-main/index.html
+++ b/Insight_Quirk-main/index.html
@@ -598,7 +598,7 @@
                     <a href="https://www.linkedin.com/company/insight-quirks/?viewAsMember=true">
                         <img src="./images/icons8-linkedin-50 (1).png" alt="LinkedIn">
                     </a>
-                    <a href="https://discord.gg/uskbwh53">
+                    <a href="https://discord.gg/33zXkAKgWC">
                         <img src="./images/icons8-discord-50.png" alt="Discord">
                     </a>
                     <a href="https://instagram.com/insightquirks?igshid=MzRlODBiNWFlZA==">


### PR DESCRIPTION
https://discord.gg/33zXkAKgWC - never expiring link (new link/never expiring)

https://discord.gg/uskbwh53 -  expired link (now removed in this PR).